### PR TITLE
feat: Add document re-indexing feature

### DIFF
--- a/maestro_frontend/src/features/documents/api.ts
+++ b/maestro_frontend/src/features/documents/api.ts
@@ -121,6 +121,11 @@ export const cancelDocumentProcessing = async (docId: string): Promise<any> => {
   return response.data;
 };
 
+export const reindexDocument = async (docId: string): Promise<any> => {
+  const response = await apiClient.post(`/api/documents/${docId}/reindex`);
+  return response.data;
+};
+
 // Metadata editing and document viewing API calls
 export interface DocumentMetadataUpdate {
   title?: string;

--- a/maestro_frontend/src/features/documents/components/EnhancedDocumentList.tsx
+++ b/maestro_frontend/src/features/documents/components/EnhancedDocumentList.tsx
@@ -10,13 +10,15 @@ import {
   BookOpen,
   Upload,
   Edit,
-  Eye
+  Eye,
+  RefreshCw
 } from 'lucide-react';
 import type { Document } from '../types';
 import { 
   bulkDeleteDocuments, 
   bulkAddDocumentsToGroup, 
-  bulkRemoveDocumentsFromGroup
+  bulkRemoveDocumentsFromGroup,
+  reindexDocument
 } from '../api';
 import { useDocumentContext } from '../context/DocumentContext';
 import { DeleteConfirmationModal } from '../../../components/ui/DeleteConfirmationModal';
@@ -302,6 +304,18 @@ export const EnhancedDocumentList: React.FC<EnhancedDocumentListProps> = ({
     setSelectedDocument(null);
   }, []);
 
+  const handleReindex = useCallback(async (docId: string) => {
+    try {
+      await reindexDocument(docId);
+      // Show a success toast or notification
+      console.log(`Document ${docId} is being re-indexed.`);
+      onDocumentAdded?.(); // Refresh the list
+    } catch (err) {
+      setError(`Failed to re-index document ${docId}`);
+      console.error('Re-index error:', err);
+    }
+  }, [onDocumentAdded]);
+
   return (
     <div 
       className={`h-full bg-background flex flex-col relative ${isDragOver ? 'bg-primary/5' : ''}`}
@@ -512,6 +526,16 @@ export const EnhancedDocumentList: React.FC<EnhancedDocumentListProps> = ({
                             title="Edit metadata"
                           >
                             <Edit className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleReindex(doc.id);
+                            }}
+                            className="p-1 text-muted-foreground hover:text-primary rounded transition-colors"
+                            title="Re-index document"
+                          >
+                            <RefreshCw className="h-4 w-4" />
                           </button>
                         </div>
                       )}


### PR DESCRIPTION
This commit introduces a new feature that allows users to re-index a document from the UI.

The changes include:

- A new backend API endpoint `POST /api/documents/{document_id}/reindex` to handle re-indexing requests.
- CRUD functions to clean up existing document data (vectors, chunks, metadata) and re-queue the document for processing.
- A "Re-index" button on the document list in the frontend.
- A new frontend API function to call the re-indexing endpoint.

This feature provides users with a way to re-process documents with the latest settings without having to delete and re-upload them.