### PR TITLE
Fix(planning): Resolve planning agent failure by removing PlanStep sc…

### DIFF
--- a/maestro_backend/ai_researcher/agentic_layer/agents/planning_agent.py
+++ b/maestro_backend/ai_researcher/agentic_layer/agents/planning_agent.py
@@ -187,7 +187,6 @@ Planning Guidelines:
         "title": "Subsection Title 1", // From suggestion
         "description": "Detailed description for subsection 1.", // From suggestion or generated based on goal
         "associated_note_ids": ["note_sub_B", "note_sub_C"], // Notes specific to this subsection
-        // No depends_on_steps field needed
         "subsections": [], // Subsections CANNOT have further nesting (depth limit)
         "research_strategy": "research_based" // Or other appropriate strategy based on analysis
         }
@@ -349,13 +348,9 @@ Planning Guidelines:
 
             # Use the centralized JSON utilities to parse and prepare the response
             parsed_data = parse_llm_json_response(json_str)
-            prepared_data = prepare_for_pydantic_validation(parsed_data, SimplifiedPlanResponse)
 
-            # --- Remove steps field if present (since it's no longer needed) ---
-            if 'steps' in parsed_data:
-                logger.info(f"{self.agent_name}: Removing 'steps' field from response as it's no longer needed.")
-                del parsed_data['steps']
-            # --- End Remove steps field ---
+            # Note: The 'steps' field is no longer part of the schema, so no removal is needed.
+            # Pydantic with `extra='forbid'` will handle validation.
 
             plan_response = SimplifiedPlanResponse(**parsed_data)
 

--- a/maestro_backend/ai_researcher/agentic_layer/agents/research_agent.py
+++ b/maestro_backend/ai_researcher/agentic_layer/agents/research_agent.py
@@ -29,7 +29,7 @@ from ai_researcher.dynamic_config import (
 )
 from ai_researcher.agentic_layer.tool_registry import ToolRegistry
 from ai_researcher.core_rag.query_preparer import QueryPreparer, QueryRewritingTechnique # <-- Import QueryPreparer
-from ai_researcher.agentic_layer.schemas.planning import PlanStep, ActionType, ReportSection
+from ai_researcher.agentic_layer.schemas.planning import ReportSection
 from ai_researcher.agentic_layer.schemas.research import ResearchFindings, ResearchResultResponse, Source
 from ai_researcher.agentic_layer.schemas.notes import Note
 from ai_researcher.agentic_layer.schemas.goal import GoalEntry # Import GoalEntry

--- a/maestro_backend/ai_researcher/agentic_layer/context_manager.py
+++ b/maestro_backend/ai_researcher/agentic_layer/context_manager.py
@@ -15,7 +15,7 @@ from database import crud, models
 # Use absolute imports starting from the top-level package 'ai_researcher'
 from ai_researcher.config import get_current_time
 from ai_researcher import config
-from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, PlanStep, ReportSection # <-- Import ReportSection
+from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection # <-- Import ReportSection
 from ai_researcher.agentic_layer.schemas.research import ResearchResultResponse
 from ai_researcher.agentic_layer.schemas.notes import Note # <-- Import Note schema
 from ai_researcher.agentic_layer.schemas.thought import ThoughtEntry 

--- a/maestro_backend/ai_researcher/agentic_layer/controller/core_controller.py
+++ b/maestro_backend/ai_researcher/agentic_layer/controller/core_controller.py
@@ -9,7 +9,7 @@ from ai_researcher.config import THOUGHT_PAD_CONTEXT_LIMIT
 from ai_researcher.agentic_layer.context_manager import ContextManager, MissionContext, ExecutionLogEntry
 from ai_researcher.agentic_layer.model_dispatcher import ModelDispatcher
 from ai_researcher.agentic_layer.tool_registry import ToolRegistry, ToolDefinition
-from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, PlanStep, ReportSection, SimplifiedPlanResponse
+from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection, SimplifiedPlanResponse
 from ai_researcher.agentic_layer.schemas.research import ResearchResultResponse, ResearchFindings
 from ai_researcher.agentic_layer.schemas.analysis import RequestAnalysisOutput
 from ai_researcher.agentic_layer.schemas.notes import Note

--- a/maestro_backend/ai_researcher/agentic_layer/schemas/__init__.py
+++ b/maestro_backend/ai_researcher/agentic_layer/schemas/__init__.py
@@ -2,7 +2,7 @@ from ai_researcher.agentic_layer.schemas.analysis import RequestAnalysisOutput
 from ai_researcher.agentic_layer.schemas.goal import GoalEntry
 from ai_researcher.agentic_layer.schemas.messenger import MessengerResponse
 from ai_researcher.agentic_layer.schemas.notes import Note
-from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, PlanStep, ReportSection, SimplifiedPlanResponse
+from ai_researcher.agentic_layer.schemas.planning import ReportSection, SimplifiedPlanResponse
 from ai_researcher.agentic_layer.schemas.reflection import ReflectionOutput, SuggestedSubsectionTopic
 from ai_researcher.agentic_layer.schemas.research import ResearchResultResponse, ResearchFindings
 from ai_researcher.agentic_layer.schemas.thought import ThoughtEntry

--- a/maestro_backend/ai_researcher/agentic_layer/schemas/planning.py
+++ b/maestro_backend/ai_researcher/agentic_layer/schemas/planning.py
@@ -1,18 +1,6 @@
 from pydantic import BaseModel, Field, ConfigDict # Import ConfigDict
 from typing import List, Optional, Dict, Any, Literal, ClassVar
 
-# Define possible action types for plan steps
-ActionType = Literal[
-    "document_search", # Use the document search tool
-    "web_search",      # Use the web search tool
-    "calculate",       # Use the calculator tool
-    "execute_python",  # Use the python execution tool
-    "synthesize",      # Synthesize information from previous steps
-    "write_section",   # Write a specific report section
-    "final_report",    # Compile the final report (usually the last step)
-    "ask_user"         # Ask the user for clarification (if MessengerAgent is used)
-]
-
 # NEW: Define research strategies
 ResearchStrategy = Literal[
     "research_based",           # Standard research process (search, reflect, etc.)
@@ -26,7 +14,6 @@ class ReportSection(BaseModel):
             "section_id",
             "title",
             "description",
-            "depends_on_steps",
             "associated_note_ids",
             "subsections",
             "research_strategy"
@@ -36,7 +23,6 @@ class ReportSection(BaseModel):
     section_id: str = Field(..., description="Unique identifier for the section (e.g., 'introduction', 'lit_review', 'methodology_results', 'conclusion').")
     title: str = Field(..., description="Human-readable title for the report section.")
     description: str = Field(..., description="Brief description of what this section should cover.")
-    depends_on_steps: List[str] = Field(default_factory=list, description="List of step_ids whose results are needed to write this section.")
     associated_note_ids: Optional[List[str]] = Field(default=None, description="List of note IDs from the exploratory phase relevant to this section.") # Added field
     subsections: List['ReportSection'] = Field(default_factory=list, description="List of subsections nested under this section.")
     # --- NEW FIELDS ---
@@ -49,40 +35,6 @@ class ReportSection(BaseModel):
 
 # Update forward references to allow for recursive subsections
 ReportSection.model_rebuild()
-
-class StepParameters(BaseModel):
-    """Parameters for different step types."""
-    query: Optional[str] = Field(None, description="Search query for document_search or web_search")
-    n_results: Optional[int] = Field(None, description="Number of results for search")
-    expression: Optional[str] = Field(None, description="Expression to calculate")
-    code: Optional[str] = Field(None, description="Python code to execute")
-    section_id: Optional[str] = Field(None, description="Section ID for write_section")
-    max_results: Optional[int] = Field(None, description="Maximum results for web search")
-    filepath: Optional[str] = Field(None, description="File path for read_full_document")
-    url: Optional[str] = Field(None, description="URL for fetch_web_page_content")
-    
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', json_schema_extra={
-        "required": [
-            "query",
-            "n_results", 
-            "expression",
-            "code",
-            "section_id",
-            "max_results",
-            "filepath",
-            "url"
-        ]
-    })
-
-class PlanStep(BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid')  # Enforce additionalProperties: false in schema
-    """Defines a single step in the research plan."""
-    step_id: str = Field(..., description="Unique identifier for this step (e.g., 'step_1', 'step_2a').")
-    action_type: ActionType = Field(..., description="The type of action to perform for this step.")
-    description: str = Field(..., description="Detailed description of what needs to be done in this step.")
-    parameters: StepParameters = Field(default_factory=StepParameters)  # Remove description to avoid $ref conflict
-    depends_on: List[str] = Field(default_factory=list, description="List of step_ids that must be completed before this step can start.")
-    produces: Optional[str] = Field(None, description="Optional description of the expected output or artifact from this step (e.g., 'list of relevant paper snippets', 'calculated value', 'synthesized findings on topic X').")
 
 class SimplifiedPlan(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid')  # Enforce additionalProperties: false in schema

--- a/maestro_backend/ai_researcher/ui/app.py
+++ b/maestro_backend/ai_researcher/ui/app.py
@@ -17,7 +17,7 @@ from ai_researcher.agentic_layer.context_manager import ExecutionLogEntry
 from ai_researcher.ui.file_converters import markdown_to_pdf, markdown_to_docx
 
 # Import schemas needed for plan parsing
-from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection, PlanStep
+from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection
 
 # --- Define Project Root Early ---
 # Needed for path configurations below
@@ -933,18 +933,9 @@ if st.session_state.mission_status in ["running", "conducting_research", "warnin
                                                      ))
                                                  return sections
                                              parsed_outline = parse_sections(plan_data.get('report_outline', []))
-                                             parsed_steps = []
-                                             for step_data in plan_data.get('steps', []):
-                                                  parsed_steps.append(PlanStep(
-                                                      step_id=step_data.get('step_id', str(uuid.uuid4())),
-                                                      description=step_data.get('description', 'No description'),
-                                                      action_type=step_data.get('action_type'), # <-- Added missing field
-                                                      target_section_id=step_data.get('target_section_id')
-                                                  ))
                                              parsed_plan = SimplifiedPlan(
                                                  mission_goal=plan_data.get('mission_goal', 'Goal not specified'),
-                                                 report_outline=parsed_outline,
-                                                 steps=parsed_steps
+                                                 report_outline=parsed_outline
                                              )
                                              st.session_state.mission_plan = parsed_plan
                                              logger.info(f"UI: Updated mission plan by parsing '{log_entry.action}' log entry.")

--- a/maestro_backend/ai_researcher/ui/gradio_app.py
+++ b/maestro_backend/ai_researcher/ui/gradio_app.py
@@ -17,7 +17,7 @@ from gradio.themes.utils import colors, fonts, sizes
 if TYPE_CHECKING:
     from ai_researcher.agentic_layer.agent_controller import AgentController
     from ai_researcher.agentic_layer.context_manager import ContextManager, ExecutionLogEntry, MissionContext
-    from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection, PlanStep
+    from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection
     from ai_researcher.core_rag.embedder import TextEmbedder
     from ai_researcher.core_rag.pgvector_store import PGVectorStore as VectorStore
     from ai_researcher.core_rag.reranker import TextReranker
@@ -51,7 +51,7 @@ except NameError:
 # --- Imports from ai_researcher (Placeholders - adjust as needed) ---
 try:
     from ai_researcher.agentic_layer.context_manager import ExecutionLogEntry, MissionContext
-    from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection, PlanStep
+    from ai_researcher.agentic_layer.schemas.planning import SimplifiedPlan, ReportSection
     from ai_researcher.core_rag.embedder import TextEmbedder
     from ai_researcher.core_rag.pgvector_store import PGVectorStore as VectorStore
     from ai_researcher.core_rag.reranker import TextReranker
@@ -89,9 +89,6 @@ except ImportError as e:
         """Placeholder class for ReportSection when imports fail."""
         pass
     
-    class PlanStep:
-        """Placeholder class for PlanStep when imports fail."""
-        pass
 
 # --- Custom Gradio Theme Definition ---
 class RetroAcademicTheme(Base):


### PR DESCRIPTION
…hema

The planning agent was consistently failing on the initial batch due to a `RuntimeError` caused by JSON validation failures. This was traced back to an inconsistency in the data schemas. The `planning_agent` was instructed not to generate a `steps` array, but the `ReportSection` schema still required a `depends_on_steps` field, creating a contradiction that confused the LLM.

This commit resolves the issue by removing the concept of `PlanStep` entirely:

- Deletes `PlanStep`, `StepParameters`, and `ActionType` from `schemas/planning.py`.
- Removes the `depends_on_steps` field from the `ReportSection` schema.
- Updates the `planning_agent.py` to remove the defensive code for deleting the `steps` field and cleans up the system prompt.
- Scrubs all remaining imports and references to the deleted classes from agents, controllers, and UI files to prevent `ImportError`s.