### PR TITLE
feat(ui): Enhance logging and prepare for interactivity

### DIFF
--- a/maestro_frontend/src/components/mission/LogEntryCard.tsx
+++ b/maestro_frontend/src/components/mission/LogEntryCard.tsx
@@ -4,6 +4,7 @@ import type { ExecutionLogEntry } from './AgentActivityLog';
 import { ActionParser } from './ActionParser';
 import { formatActivityLogTime } from '../../utils/timezone';
 import { getAgentIcon, getAgentColorClass } from './agentIcons';
+import { ModelDetailsRenderer } from './ModelDetailsRenderer';
 
 interface LogEntryCardProps {
   log: ExecutionLogEntry;
@@ -148,24 +149,6 @@ export const LogEntryCard: React.FC<LogEntryCardProps> = ({
             </p>
           )}
         </div>
-
-        {/* Compact Model Details - Smaller and more beautified */}
-        {log.model_details && (
-          <div className="flex-shrink-0">
-            <div className="flex items-center space-x-1">
-              {log.model_details.cost !== undefined && log.model_details.cost !== null && (
-                <div className="bg-green-500/10 text-green-500 px-1.5 py-0.5 rounded-full text-xs font-medium">
-                  ${log.model_details.cost.toFixed(4)}
-                </div>
-              )}
-              {log.model_details.duration_sec && (
-                <div className="bg-primary/10 text-primary px-1.5 py-0.5 rounded-full text-xs font-medium">
-                  {log.model_details.duration_sec.toFixed(1)}s
-                </div>
-              )}
-            </div>
-          </div>
-        )}
       </div>
 
       {/* Expanded Content */}
@@ -174,6 +157,7 @@ export const LogEntryCard: React.FC<LogEntryCardProps> = ({
           <div className="p-3 overflow-hidden">
             <div className="max-w-full overflow-x-auto">
               {children}
+              <ModelDetailsRenderer log={log} />
             </div>
           </div>
         </div>

--- a/maestro_frontend/src/components/mission/MissionHeaderStats.tsx
+++ b/maestro_frontend/src/components/mission/MissionHeaderStats.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
-import { DollarSign, Search, Clock, Zap } from 'lucide-react';
+import { DollarSign, Search, Clock, Zap, Pause, Square } from 'lucide-react';
 import type { ExecutionLogEntry } from './AgentActivityLog';
+import { Button } from '../ui/button';
 
 interface MissionHeaderStatsProps {
   logs: ExecutionLogEntry[];
@@ -65,42 +66,55 @@ export const MissionHeaderStats: React.FC<MissionHeaderStatsProps> = ({
   }
 
   return (
-    <div className="flex items-center space-x-2 text-xs">
-      {/* Total Cost */}
-      <div className="flex items-center space-x-1">
-        <DollarSign className="h-3 w-3 text-green-600" />
-        <span className="text-green-700 font-medium">
-          {formatCurrency(stats.totalCost)}
-        </span>
-      </div>
-
-      {/* Web Searches */}
-      <div className="flex items-center space-x-1">
-        <Search className="h-3 w-3 text-blue-600" />
-        <span className="text-blue-700 font-medium">
-          {stats.webSearches}
-        </span>
-      </div>
-
-      {/* Duration (only show if mission has run) */}
-      {stats.totalDuration > 0 && (
+    <div className="flex justify-between items-center w-full">
+      <div className="flex items-center space-x-2 text-xs">
+        {/* Total Cost */}
         <div className="flex items-center space-x-1">
-          <Clock className="h-3 w-3 text-purple-600" />
-          <span className="text-purple-700 font-medium">
-            {formatDuration(stats.totalDuration)}
+          <DollarSign className="h-3 w-3 text-green-600" />
+          <span className="text-green-700 font-medium">
+            {formatCurrency(stats.totalCost)}
           </span>
         </div>
-      )}
 
-      {/* Tokens (only show if significant) */}
-      {stats.totalTokens > 0 && (
+        {/* Web Searches */}
         <div className="flex items-center space-x-1">
-          <Zap className="h-3 w-3 text-orange-600" />
-          <span className="text-orange-700 font-medium">
-            {formatNumber(stats.totalTokens)}
+          <Search className="h-3 w-3 text-blue-600" />
+          <span className="text-blue-700 font-medium">
+            {stats.webSearches}
           </span>
         </div>
-      )}
+
+        {/* Duration (only show if mission has run) */}
+        {stats.totalDuration > 0 && (
+          <div className="flex items-center space-x-1">
+            <Clock className="h-3 w-3 text-purple-600" />
+            <span className="text-purple-700 font-medium">
+              {formatDuration(stats.totalDuration)}
+            </span>
+          </div>
+        )}
+
+        {/* Tokens (only show if significant) */}
+        {stats.totalTokens > 0 && (
+          <div className="flex items-center space-x-1">
+            <Zap className="h-3 w-3 text-orange-600" />
+            <span className="text-orange-700 font-medium">
+              {formatNumber(stats.totalTokens)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Button variant="outline" size="sm" disabled>
+          <Pause className="h-4 w-4 mr-2" />
+          Pause
+        </Button>
+        <Button variant="destructive" size="sm" disabled>
+          <Square className="h-4 w-4 mr-2" />
+          Stop
+        </Button>
+      </div>
     </div>
   );
 };

--- a/maestro_frontend/src/components/mission/ModelDetailsRenderer.tsx
+++ b/maestro_frontend/src/components/mission/ModelDetailsRenderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Cpu, Zap, ChevronsRight } from 'lucide-react';
 import type { ExecutionLogEntry } from './AgentActivityLog';
 
 interface ModelDetailsRendererProps {
@@ -8,38 +9,51 @@ interface ModelDetailsRendererProps {
 export const ModelDetailsRenderer: React.FC<ModelDetailsRendererProps> = ({ log }) => {
   if (!log.model_details) return null;
 
+  const {
+    provider,
+    model_name,
+    duration_sec,
+    prompt_tokens,
+    completion_tokens,
+    total_tokens,
+    cost,
+  } = log.model_details;
+
   return (
-    <div className="mb-4">
-      <h4 className="text-sm font-semibold text-gray-700 mb-2">Model Performance</h4>
-      <div className="bg-white border border-gray-200 rounded p-3">
-        <div className="grid grid-cols-2 gap-4 text-xs">
-          <div>
-            <div className="text-gray-600">Provider:</div>
-            <div className="font-medium">{log.model_details.provider}</div>
+    <div className="mt-2 p-2 bg-gray-50 rounded">
+      <div className="flex items-center text-xs text-gray-500 mb-2">
+        <Cpu className="h-4 w-4 mr-2" />
+        <span className="font-semibold">{provider}</span>
+        <ChevronsRight className="h-4 w-4 mx-1" />
+        <span>{model_name}</span>
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-600">
+        {duration_sec && (
+          <div className="flex items-center">
+            <Zap className="h-3 w-3 mr-1" />
+            <span>{duration_sec.toFixed(2)}s</span>
           </div>
+        )}
+        {prompt_tokens && (
           <div>
-            <div className="text-gray-600">Model:</div>
-            <div className="font-medium font-mono">{log.model_details.model_name}</div>
+            <span className="font-medium">P:</span> {prompt_tokens}
           </div>
+        )}
+        {completion_tokens && (
           <div>
-            <div className="text-gray-600">Duration:</div>
-            <div className="font-medium">{log.model_details.duration_sec?.toFixed(2)}s</div>
+            <span className="font-medium">C:</span> {completion_tokens}
           </div>
-          {log.model_details.cost !== undefined && log.model_details.cost !== null && (
-            <div>
-              <div className="text-gray-600">Cost:</div>
-              <div className="font-medium">${log.model_details.cost.toFixed(4)}</div>
-            </div>
-          )}
-          {log.model_details.total_tokens && (
-            <div className="col-span-2">
-              <div className="text-gray-600">Tokens:</div>
-              <div className="font-medium">
-                {log.model_details.prompt_tokens} + {log.model_details.completion_tokens} = {log.model_details.total_tokens}
-              </div>
-            </div>
-          )}
-        </div>
+        )}
+        {total_tokens && (
+          <div>
+            <span className="font-medium">T:</span> {total_tokens}
+          </div>
+        )}
+        {cost && (
+          <div>
+            <span className="font-medium">Cost:</span> ${cost.toFixed(6)}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/maestro_frontend/src/components/mission/PlanningAgentLog.tsx
+++ b/maestro_frontend/src/components/mission/PlanningAgentLog.tsx
@@ -171,10 +171,23 @@ export const PlanningAgentLog: React.FC<PlanningAgentLogProps> = ({ log, isExpan
       {renderPlanningOutput()}
       <ToolCallsRenderer log={log} />
       
-      {log.full_output && (
-        <details className="group">
+      {log.full_input && (
+        <details className="group" open>
           <summary className={`text-sm font-semibold ${themeColors.contentText} cursor-pointer hover:text-foreground`}>
-            📊 Raw Planning Data
+            Raw Input Data
+          </summary>
+          <div className={`mt-2 ${themeColors.codeBg} p-3 rounded`}>
+            <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">
+              {stringifyCleanLogData(log.full_input, 2)}
+            </pre>
+          </div>
+        </details>
+      )}
+
+      {log.full_output && (
+        <details className="group" open>
+          <summary className={`text-sm font-semibold ${themeColors.contentText} cursor-pointer hover:text-foreground`}>
+            Raw Output Data
           </summary>
           <div className={`mt-2 ${themeColors.codeBg} p-3 rounded`}>
             <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">

--- a/maestro_frontend/src/components/mission/ReflectionAgentLog.tsx
+++ b/maestro_frontend/src/components/mission/ReflectionAgentLog.tsx
@@ -224,6 +224,32 @@ export const ReflectionAgentLog: React.FC<ReflectionAgentLogProps> = ({ log, isE
     <div className="p-4 space-y-4">
       {renderReflectionOutput()}
       <ToolCallsRenderer log={log} />
+
+      {log.full_input && (
+        <details className="group" open>
+          <summary className="text-sm font-semibold text-gray-700 cursor-pointer hover:text-gray-900">
+            Raw Input Data
+          </summary>
+          <div className="mt-2 bg-gray-100 p-3 rounded">
+            <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">
+              {stringifyCleanLogData(log.full_input, 2)}
+            </pre>
+          </div>
+        </details>
+      )}
+
+      {log.full_output && (
+        <details className="group" open>
+          <summary className="text-sm font-semibold text-gray-700 cursor-pointer hover:text-gray-900">
+            Raw Output Data
+          </summary>
+          <div className="mt-2 bg-gray-100 p-3 rounded">
+            <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">
+              {stringifyCleanLogData(log.full_output, 2)}
+            </pre>
+          </div>
+        </details>
+      )}
     </div>
   );
 };

--- a/maestro_frontend/src/components/mission/ResearchAgentLog.tsx
+++ b/maestro_frontend/src/components/mission/ResearchAgentLog.tsx
@@ -126,10 +126,23 @@ export const ResearchAgentLog: React.FC<ResearchAgentLogProps> = ({ log, isExpan
       <ToolCallsRenderer log={log} />
       {renderFileInteractions()}
       
-      {log.full_output && (
-        <details className="group">
+      {log.full_input && (
+        <details className="group" open>
           <summary className="text-sm font-semibold text-gray-700 cursor-pointer hover:text-gray-900">
-            🔧 Raw Research Data
+            Raw Input Data
+          </summary>
+          <div className="mt-2 bg-gray-100 p-3 rounded">
+            <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">
+              {stringifyCleanLogData(log.full_input, 2)}
+            </pre>
+          </div>
+        </details>
+      )}
+
+      {log.full_output && (
+        <details className="group" open>
+          <summary className="text-sm font-semibold text-gray-700 cursor-pointer hover:text-gray-900">
+            Raw Output Data
           </summary>
           <div className="mt-2 bg-gray-100 p-3 rounded">
             <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">

--- a/maestro_frontend/src/components/mission/WritingAgentLog.tsx
+++ b/maestro_frontend/src/components/mission/WritingAgentLog.tsx
@@ -117,6 +117,32 @@ export const WritingAgentLog: React.FC<WritingAgentLogProps> = ({ log, isExpande
       {renderWritingOutput()}
       {renderWritingDetails()}
       <ToolCallsRenderer log={log} />
+
+      {log.full_input && (
+        <details className="group" open>
+          <summary className="text-sm font-semibold text-gray-700 cursor-pointer hover:text-gray-900">
+            Raw Input Data
+          </summary>
+          <div className="mt-2 bg-gray-100 p-3 rounded">
+            <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">
+              {stringifyCleanLogData(log.full_input, 2)}
+            </pre>
+          </div>
+        </details>
+      )}
+
+      {log.full_output && (
+        <details className="group" open>
+          <summary className="text-sm font-semibold text-gray-700 cursor-pointer hover:text-gray-900">
+            Raw Output Data
+          </summary>
+          <div className="mt-2 bg-gray-100 p-3 rounded">
+            <pre className="text-xs overflow-x-auto max-h-64 overflow-y-auto">
+              {stringifyCleanLogData(log.full_output, 2)}
+            </pre>
+          </div>
+        </details>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces several improvements to the UI to provide more detailed logging and prepare for future interactivity.

Key changes:
- Adds disabled "Pause" and "Stop" buttons to the mission header to earmark their future implementation.
- Adds expandable sections to the agent log entries to display raw LLM input and output, improving transparency.
- Refactors the display of model performance details into a new `ModelDetailsRenderer` component for better organization and readability.
- Sets the raw input and output sections to be expanded by default for better visibility.