### PR TITLE
Fix AttributeError for missing attributes in OutlineModification

### DIFF
--- a/maestro_backend/ai_researcher/agentic_layer/controller/reflection_manager.py
+++ b/maestro_backend/ai_researcher/agentic_layer/controller/reflection_manager.py
@@ -269,7 +269,7 @@ class ReflectionManager:
                            # Use section_id from the tuple, not output.section_id
                            f"- Structural Modification Suggestion (for section '{section_id}'):\n"
                            f"    Type='{mod.modification_type}', Target ID='{mod.target_section_id}', "
-                           f"New Title='{mod.new_title}', New Description='{mod.new_description}', "
+                           f"New Title='{mod.details.new_title}', New Description='{mod.details.new_topic}', "
                            f"Reasoning='{mod.reasoning}'"
                       )
                       total_structural_suggestions += 1

--- a/maestro_backend/ai_researcher/agentic_layer/schemas/reflection.py
+++ b/maestro_backend/ai_researcher/agentic_layer/schemas/reflection.py
@@ -40,6 +40,7 @@ class OutlineModification(BaseModel):
     Represents a single proposed modification to the research outline.
     """
     modification_type: OutlineModificationType = Field(..., description="The type of change proposed.")
+    target_section_id: Optional[str] = Field(None, description="The ID of the section this modification applies to.")
     details: ModificationDetails = Field(...)  # Remove description to avoid $ref conflict
     reasoning: str = Field(..., description="Explanation from the agent on why this modification is suggested.")
 


### PR DESCRIPTION
The `reflection_manager.py` was attempting to access `target_section_id`, `new_title`, and `new_description` directly on the `OutlineModification` Pydantic model, which caused a fatal `AttributeError`.

This commit resolves the issue by:
1. Adding the `target_section_id` field to the `OutlineModification` model in `reflection.py` to align the schema with its usage.
2. Correcting the attribute access in `reflection_manager.py` to use the `details` attribute for `new_title` and `new_topic` (correcting `new_description` to `new_topic`).

These changes ensure that the reflection process can proceed without crashing due to model and data access mismatches.