### PR TITLE
feat: Implement backend health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     volumes:
       - maestro-data:/app/ai_researcher/data
       - ./maestro_model_cache:/root/.cache/huggingface
@@ -96,7 +102,8 @@ services:
     # ports:
     #   - "${FRONTEND_HOST}:${FRONTEND_PORT}:${FRONTEND_INTERNAL_PORT}"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - maestro-network
     environment:

--- a/maestro_backend/main.py
+++ b/maestro_backend/main.py
@@ -21,6 +21,11 @@ app = FastAPI(
     version="2.0.0-alpha"
 )
 
+@app.get("/api/health")
+def health_check():
+    """Simple health check endpoint."""
+    return {"status": "healthy"}
+
 # Configure CORS with environment variables
 def get_cors_origins():
     """Get CORS allowed origins from environment variables."""
@@ -257,6 +262,3 @@ def read_root():
         "docs": "/docs"
     }
 
-@app.get("/health")
-def health_check():
-    return {"status": "healthy"}


### PR DESCRIPTION
This change introduces a formal health check for the backend service.

A new `/api/health` endpoint is added to the FastAPI application. This endpoint is lightweight and does not depend on any other services, making it a reliable way to check the health of the backend.

The `docker-compose.yml` file is updated to include a `healthcheck` for the `backend` service. This healthcheck polls the new `/api/health` endpoint to ensure the service is running and responsive.

The `frontend` service is also updated to depend on the `backend` service's health, ensuring that the frontend does not start until the backend is ready to accept connections.

An old `/health` endpoint has been removed to avoid confusion.