### PR TITLE
Fix 'Cannot build draft' error and document test suite issues.

### DIFF
--- a/maestro_backend/ai_researcher/agentic_layer/agents/reflection_agent.py
+++ b/maestro_backend/ai_researcher/agentic_layer/agents/reflection_agent.py
@@ -10,7 +10,6 @@ from ai_researcher.agentic_layer.model_dispatcher import ModelDispatcher
 from ai_researcher.agentic_layer.schemas.planning import ReportSection
 # Import the updated schema components
 from ai_researcher.agentic_layer.schemas.reflection import ReflectionOutput, SuggestedSubsectionTopic, OutlineModification
-from ai_researcher.agentic_layer.context_manager import MissionContext
 from ai_researcher.agentic_layer.schemas.notes import Note
 from ai_researcher.agentic_layer.schemas.goal import GoalEntry
 from ai_researcher.agentic_layer.schemas.thought import ThoughtEntry
@@ -71,7 +70,7 @@ class ReflectionAgent(BaseAgent):
 
     def _prepare_reflection_prompt(
         self,
-        mission_context: MissionContext, # Still needed for overall goal and outline structure
+        mission_context: 'MissionContext', # Still needed for overall goal and outline structure
         section_id: str,
         section_title: str, # Added
         section_goal: str,  # Added (was description)
@@ -202,7 +201,7 @@ Provide ONLY a single JSON object conforming EXACTLY to the ReflectionOutput sch
 
     async def run( # <-- Make method async
         self,
-        mission_context: MissionContext,
+        mission_context: 'MissionContext',
         section_id: str,
         section_title: str, # Added
         section_goal: str,  # Added

--- a/maestro_backend/ai_researcher/agentic_layer/context_manager.py
+++ b/maestro_backend/ai_researcher/agentic_layer/context_manager.py
@@ -1082,8 +1082,8 @@ class ContextManager:
         for structure and hierarchical numbering. Returns None if prerequisites are missing.
         """
         mission_context = self.get_mission_context(mission_id)
-        if not mission_context or not mission_context.plan or not mission_context.report_content:
-            logger.error(f"Cannot build draft: Mission context, plan, or report content missing for {mission_id}.")
+        if not mission_context or not mission_context.plan:
+            logger.error(f"Cannot build draft: Mission context or plan missing for {mission_id}.")
             return None
 
         full_draft = ""

--- a/maestro_backend/ai_researcher/main_cli.py
+++ b/maestro_backend/ai_researcher/main_cli.py
@@ -483,7 +483,7 @@ def run_research( # Changed to synchronous 'def'
         retriever = Retriever(embedder=embedder, vector_store=vector_store, reranker=reranker)
 
         # Agentic Layer Components
-        model_dispatcher = ModelDispatcher() # Assumes API keys are in env
+        model_dispatcher = ModelDispatcher({}) # Assumes API keys are in env
         query_preparer = QueryPreparer(model_dispatcher)
         query_strategist = QueryStrategist(model_dispatcher)
         tool_registry = ToolRegistry()


### PR DESCRIPTION
This commit addresses the 'Cannot build draft' error and represents a significant effort to repair the project's test suite.

Summary of actions taken:

1.  **Initial Fix:** The original error, "Cannot build draft: Mission context, plan, or report content missing," was traced to `context_manager.py`. The check was too strict, failing when a mission had a plan but no report content. I relaxed this check to allow draft building in this state.

2.  **Test Suite Repair Attempt:** Adding a test for the fix revealed a deeply broken test suite with widespread errors. My subsequent efforts focused on repairing it:
    *   I initially misdiagnosed the problem as a `PYTHONPATH` issue and incorrectly changed dozens of import statements across all test files from `ai_researcher...` to `maestro_backend.ai_researcher...`.
    *   After realizing this was the wrong approach, I reverted all test files to their original state.
    *   I then attempted to run the tests from the correct directory (`maestro_backend/`) to properly configure the environment.

3.  **Current Status (Stuck):** My final test run revealed 18 failures. These failures are not simple import errors but deep issues within the tests themselves, including:
    *   `AttributeError`: Tests are calling methods that no longer exist on the `AgentController` (e.g., `_generate_preliminary_outline`, `_process_citations`), indicating the tests have not been updated after a major code refactoring.
    *   `pydantic.ValidationError`: A test in `test_agent_controller.py` fails because it tries to instantiate the `SimplifiedPlan` schema with an incorrect structure.
    *   `AssertionError` / `FileNotFoundError`: Many other tests are failing due to incorrect mocks, flawed test data (e.g., the `test_research_agent.py` windowing issue), or missing test files.

Conclusion: While the original bug is fixed, the test suite is in a non-working state and requires a more systematic effort to synchronize it with the refactored application code. I was unable to complete this within the given constraints.